### PR TITLE
Add defaultDotColor game config property.

### DIFF
--- a/build/engine.d.ts
+++ b/build/engine.d.ts
@@ -57,10 +57,9 @@ interface GameConfig {
      */
     frameRate?: number;
     /**
-     * Set the color used when clearing the screen. By default, this is set to
-     * *Color.GREY*.
+     * Set the default color of the dots. By default, this is set to *Color.Gray*.
      */
-    clearColor?: Color;
+    defaultDotColor?: Color;
     /**
      * @ignore
      *

--- a/build/engine.d.ts
+++ b/build/engine.d.ts
@@ -57,6 +57,11 @@ interface GameConfig {
      */
     frameRate?: number;
     /**
+     * Set the color used when clearing the screen. By default, this is set to
+     * *Color.GREY*.
+     */
+    clearColor?: Color;
+    /**
      * @ignore
      *
      * Sets the width of the grid

--- a/build/engine.js
+++ b/build/engine.js
@@ -242,7 +242,7 @@ var Game = /** @class */ (function () {
         var _this = this;
         this._dots.forEach(function (row, y) {
             for (var x = 0; x < row.length; x++) {
-                _this.setDot(x, y, Color.Gray);
+                _this.setDot(x, y, _this._config.clearColor || Color.Gray);
             }
         });
     };

--- a/build/engine.js
+++ b/build/engine.js
@@ -242,7 +242,7 @@ var Game = /** @class */ (function () {
         var _this = this;
         this._dots.forEach(function (row, y) {
             for (var x = 0; x < row.length; x++) {
-                _this.setDot(x, y, _this._config.clearColor || Color.Gray);
+                _this.setDot(x, y, _this._config.defaultDotColor || Color.Gray);
             }
         });
     };

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -54,10 +54,11 @@ let config = { create: create, // A function you&amp;#39;ve defined  update: upd
       
       <guid>http://24a2.routley.io/reference/interfaces/gameconfig/</guid>
       <description>GameConfig is the object you pass when contructing a new Game.
-Hierarchy  GameConfig  Index Properties  containerId create frameRate onDotClicked onKeyPress update  Properties Optional containerId • containerId? : undefined | string
+Hierarchy  GameConfig  Index Properties  clearColor containerId create frameRate onDotClicked onKeyPress update  Properties Optional clearColor • clearColor? : Color
+Set the color used when clearing the screen. By default, this is set to Color.GREY.
+Optional containerId • containerId? : undefined | string
 The ID of a container to create the canvas in
-Optional create • create? : undefined | function
-create is a function which is called once, just before the game starts running. You can use it to initialise game state, if needed.</description>
+Optional create • create?</description>
     </item>
     
     <item>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -54,11 +54,10 @@ let config = { create: create, // A function you&amp;#39;ve defined  update: upd
       
       <guid>http://24a2.routley.io/reference/interfaces/gameconfig/</guid>
       <description>GameConfig is the object you pass when contructing a new Game.
-Hierarchy  GameConfig  Index Properties  clearColor containerId create frameRate onDotClicked onKeyPress update  Properties Optional clearColor • clearColor? : Color
-Set the color used when clearing the screen. By default, this is set to Color.GREY.
-Optional containerId • containerId? : undefined | string
+Hierarchy  GameConfig  Index Properties  containerId create defaultDotColor frameRate onDotClicked onKeyPress update  Properties Optional containerId • containerId? : undefined | string
 The ID of a container to create the canvas in
-Optional create • create?</description>
+Optional create • create? : undefined | function
+create is a function which is called once, just before the game starts running. You can use it to initialise game state, if needed.</description>
     </item>
     
     <item>

--- a/docs/js/engine.js
+++ b/docs/js/engine.js
@@ -242,7 +242,7 @@ var Game = /** @class */ (function () {
         var _this = this;
         this._dots.forEach(function (row, y) {
             for (var x = 0; x < row.length; x++) {
-                _this.setDot(x, y, Color.Gray);
+                _this.setDot(x, y, _this._config.clearColor || Color.Gray);
             }
         });
     };

--- a/docs/js/engine.js
+++ b/docs/js/engine.js
@@ -242,7 +242,7 @@ var Game = /** @class */ (function () {
         var _this = this;
         this._dots.forEach(function (row, y) {
             for (var x = 0; x < row.length; x++) {
-                _this.setDot(x, y, _this._config.clearColor || Color.Gray);
+                _this.setDot(x, y, _this._config.defaultDotColor || Color.Gray);
             }
         });
     };

--- a/docs/reference/index.xml
+++ b/docs/reference/index.xml
@@ -54,11 +54,10 @@ let config = { create: create, // A function you&amp;#39;ve defined  update: upd
       
       <guid>http://24a2.routley.io/reference/interfaces/gameconfig/</guid>
       <description>GameConfig is the object you pass when contructing a new Game.
-Hierarchy  GameConfig  Index Properties  clearColor containerId create frameRate onDotClicked onKeyPress update  Properties Optional clearColor • clearColor? : Color
-Set the color used when clearing the screen. By default, this is set to Color.GREY.
-Optional containerId • containerId? : undefined | string
+Hierarchy  GameConfig  Index Properties  containerId create defaultDotColor frameRate onDotClicked onKeyPress update  Properties Optional containerId • containerId? : undefined | string
 The ID of a container to create the canvas in
-Optional create • create?</description>
+Optional create • create? : undefined | function
+create is a function which is called once, just before the game starts running. You can use it to initialise game state, if needed.</description>
     </item>
     
   </channel>

--- a/docs/reference/index.xml
+++ b/docs/reference/index.xml
@@ -54,10 +54,11 @@ let config = { create: create, // A function you&amp;#39;ve defined  update: upd
       
       <guid>http://24a2.routley.io/reference/interfaces/gameconfig/</guid>
       <description>GameConfig is the object you pass when contructing a new Game.
-Hierarchy  GameConfig  Index Properties  containerId create frameRate onDotClicked onKeyPress update  Properties Optional containerId • containerId? : undefined | string
+Hierarchy  GameConfig  Index Properties  clearColor containerId create frameRate onDotClicked onKeyPress update  Properties Optional clearColor • clearColor? : Color
+Set the color used when clearing the screen. By default, this is set to Color.GREY.
+Optional containerId • containerId? : undefined | string
 The ID of a container to create the canvas in
-Optional create • create? : undefined | function
-create is a function which is called once, just before the game starts running. You can use it to initialise game state, if needed.</description>
+Optional create • create?</description>
     </item>
     
   </channel>

--- a/docs/reference/interfaces/gameconfig/index.html
+++ b/docs/reference/interfaces/gameconfig/index.html
@@ -48,9 +48,9 @@
 <h3 id="properties">Properties</h3>
 
 <ul>
-<li><a href="../gameconfig#optional-clearcolor">clearColor</a></li>
 <li><a href="../gameconfig#optional-containerid">containerId</a></li>
 <li><a href="../gameconfig#optional-create">create</a></li>
+<li><a href="../gameconfig#optional-defaultdotcolor">defaultDotColor</a></li>
 <li><a href="../gameconfig#optional-framerate">frameRate</a></li>
 <li><a href="../gameconfig#optional-ondotclicked">onDotClicked</a></li>
 <li><a href="../gameconfig#optional-onkeypress">onKeyPress</a></li>
@@ -58,15 +58,6 @@
 </ul>
 
 <h2 id="properties-1">Properties</h2>
-
-<h3 id="optional-clearcolor"><code>Optional</code> clearColor</h3>
-
-<p>• <strong>clearColor</strong>? : <em><a href="../../enums/color">Color</a></em></p>
-
-<p>Set the color used when clearing the screen. By default, this is set to
-<em>Color.GREY</em>.</p>
-
-<hr />
 
 <h3 id="optional-containerid"><code>Optional</code> containerId</h3>
 
@@ -82,6 +73,14 @@
 
 <p><code>create</code> is a function which is called once, just before the game starts
 running. You can use it to initialise game state, if needed.</p>
+
+<hr />
+
+<h3 id="optional-defaultdotcolor"><code>Optional</code> defaultDotColor</h3>
+
+<p>• <strong>defaultDotColor</strong>? : <em><a href="../../enums/color">Color</a></em></p>
+
+<p>Set the default color of the dots. By default, this is set to <em>Color.Gray</em>.</p>
 
 <hr />
 

--- a/docs/reference/interfaces/gameconfig/index.html
+++ b/docs/reference/interfaces/gameconfig/index.html
@@ -48,6 +48,7 @@
 <h3 id="properties">Properties</h3>
 
 <ul>
+<li><a href="../gameconfig#optional-clearcolor">clearColor</a></li>
 <li><a href="../gameconfig#optional-containerid">containerId</a></li>
 <li><a href="../gameconfig#optional-create">create</a></li>
 <li><a href="../gameconfig#optional-framerate">frameRate</a></li>
@@ -57,6 +58,15 @@
 </ul>
 
 <h2 id="properties-1">Properties</h2>
+
+<h3 id="optional-clearcolor"><code>Optional</code> clearColor</h3>
+
+<p>• <strong>clearColor</strong>? : <em><a href="../../enums/color">Color</a></em></p>
+
+<p>Set the color used when clearing the screen. By default, this is set to
+<em>Color.GREY</em>.</p>
+
+<hr />
 
 <h3 id="optional-containerid"><code>Optional</code> containerId</h3>
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -61,10 +61,9 @@ interface GameConfig {
   frameRate?: number;
 
   /**
-   * Set the color used when clearing the screen. By default, this is set to 
-   * *Color.GREY*.
+   * Set the default color of the dots. By default, this is set to *Color.Gray*.
    */
-  clearColor?: Color;
+  defaultDotColor?: Color;
 
   /**
    * @ignore
@@ -344,7 +343,7 @@ class Game {
   private _clearGrid() {
     this._dots.forEach((row, y) => {
       for (let x = 0; x < row.length; x++) {
-        this.setDot(x, y, this._config.clearColor || Color.Gray);
+        this.setDot(x, y, this._config.defaultDotColor || Color.Gray);
       }
     });
   }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -61,6 +61,12 @@ interface GameConfig {
   frameRate?: number;
 
   /**
+   * Set the color used when clearing the screen. By default, this is set to 
+   * *Color.GREY*.
+   */
+  clearColor?: Color;
+
+  /**
    * @ignore
    *
    * Sets the width of the grid
@@ -338,7 +344,7 @@ class Game {
   private _clearGrid() {
     this._dots.forEach((row, y) => {
       for (let x = 0; x < row.length; x++) {
-        this.setDot(x, y, Color.Gray);
+        this.setDot(x, y, this._config.clearColor || Color.Gray);
       }
     });
   }

--- a/website/content/reference/interfaces/gameconfig.md
+++ b/website/content/reference/interfaces/gameconfig.md
@@ -14,6 +14,7 @@ GameConfig is the object you pass when contructing a new [Game](../../classes/ga
 
 ### Properties
 
+* [clearColor](../gameconfig#optional-clearcolor)
 * [containerId](../gameconfig#optional-containerid)
 * [create](../gameconfig#optional-create)
 * [frameRate](../gameconfig#optional-framerate)
@@ -22,6 +23,15 @@ GameConfig is the object you pass when contructing a new [Game](../../classes/ga
 * [update](../gameconfig#optional-update)
 
 ## Properties
+
+### `Optional` clearColor
+
+• **clearColor**? : *[Color](../../enums/color)*
+
+Set the color used when clearing the screen. By default, this is set to
+*Color.GREY*.
+
+___
 
 ### `Optional` containerId
 

--- a/website/content/reference/interfaces/gameconfig.md
+++ b/website/content/reference/interfaces/gameconfig.md
@@ -14,24 +14,15 @@ GameConfig is the object you pass when contructing a new [Game](../../classes/ga
 
 ### Properties
 
-* [clearColor](../gameconfig#optional-clearcolor)
 * [containerId](../gameconfig#optional-containerid)
 * [create](../gameconfig#optional-create)
+* [defaultDotColor](../gameconfig#optional-defaultdotcolor)
 * [frameRate](../gameconfig#optional-framerate)
 * [onDotClicked](../gameconfig#optional-ondotclicked)
 * [onKeyPress](../gameconfig#optional-onkeypress)
 * [update](../gameconfig#optional-update)
 
 ## Properties
-
-### `Optional` clearColor
-
-• **clearColor**? : *[Color](../../enums/color)*
-
-Set the color used when clearing the screen. By default, this is set to
-*Color.GREY*.
-
-___
 
 ### `Optional` containerId
 
@@ -47,6 +38,14 @@ ___
 
 `create` is a function which is called once, just before the game starts
 running. You can use it to initialise game state, if needed.
+
+___
+
+### `Optional` defaultDotColor
+
+• **defaultDotColor**? : *[Color](../../enums/color)*
+
+Set the default color of the dots. By default, this is set to *Color.Gray*.
 
 ___
 


### PR DESCRIPTION
Added requested feature in issue #6 to change the default clear color.
Should be backwards compatible since it uses Color.GREY by default.