### PR TITLE
Add "White" to the list of colors

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -17,6 +17,7 @@ enum Color {
   Blue = "BLUE",
   Indigo = "INDIGO",
   Violet = "VIOLET",
+  White = "WHITE",
 }
 
 enum Direction {
@@ -369,6 +370,8 @@ class Game {
         return "indigo";
       case Color.Violet:
         return "violet";
+      case Color.White:
+        return "white";
       default:
         console.error(`no CSS color defined for ${color}`);
         return "";


### PR DESCRIPTION
"White" is useful to not draw a dot (assuming the background is white as well).

This feature is e.g. used in the ["You Killed a Bear"](https://craigmbooth.com/projects/ykab/) featured game (linked in the README), but currently this floods the console with error messages ("no CSS color defined for WHITE").

This PR does not update the relevant documentation.