### PR TITLE
Add es6 module support

### DIFF
--- a/build/engine.d.ts
+++ b/build/engine.d.ts
@@ -7,7 +7,7 @@
  * game.setDot(x, y, Color.Red)
  * ```
  */
-declare enum Color {
+export declare enum Color {
     Gray = "GRAY",
     Black = "BLACK",
     Red = "RED",
@@ -18,7 +18,7 @@ declare enum Color {
     Indigo = "INDIGO",
     Violet = "VIOLET"
 }
-declare enum Direction {
+export declare enum Direction {
     Left = "LEFT",
     Right = "RIGHT",
     Up = "UP",
@@ -27,7 +27,7 @@ declare enum Direction {
 /**
  * GameConfig is the object you pass when contructing a new {@link Game}.
  */
-interface GameConfig {
+export interface GameConfig {
     /**
      * `create(game)` is a function which is called once, just before the game
      * starts running. You can use it to initialise game state, if needed.
@@ -104,7 +104,7 @@ interface GameConfig {
  * game.run()
  * ```
  */
-declare class Game {
+export declare class Game {
     private _config;
     private _text;
     private _ended;
@@ -157,52 +157,4 @@ declare class Game {
     private _update;
     private _clearGrid;
     private _render;
-}
-/**
- * @ignore
- * IOManager is the interface used by {@Link Game} to manage the game's input
- * (e.g. keyboard or mouse events) and output (drawing the game).
- * IOManager does not form part of 24a2's public API, and can change without
- * warning
- */
-interface IOManager {
-    setDot: (x: number, y: number, val: Color) => void;
-    setText: (text: string) => void;
-    registerDotClicked: (dotClicked: (x: number, y: number) => void) => void;
-    registerKeyPressed: (keyPressed: (direction: Direction) => void) => void;
-}
-/**
- * @ignore
- * CanvasIOManager is the object that manages 24a2's input (capturing keyboard
- * and mouse events) and output (rendering the game to a HTML Canvas). It's the
- * only bit of 24a2 which is aware we're running in a browser.
- * CanvasIOManager does not form part of 24a2's public API, and can change
- * without warning
- */
-declare class CanvasIOManager {
-    private _gridHeight;
-    private _gridWidth;
-    private _dotSize;
-    private _gapSize;
-    private _canvas;
-    private _ctx;
-    private _dotClicked?;
-    private _keyPressed?;
-    constructor(gridHeight: number, gridWidth: number, containerId?: string);
-    registerDotClicked(dotClicked: (x: number, y: number) => void): void;
-    registerKeyPressed(keyPressed: (direction: Direction) => void): void;
-    private _listenForMouseClick;
-    private _listenForKeyPress;
-    private _createCanvasContext;
-    /**
-     * Returns the element that should be our canvas's parent.
-     * - If a containerId is specified, it'll be the element with that ID
-     * - If one isn't, the parent will be the <main> element
-     * - If a <main> element doesn't exist, we'll append one to the <body>
-     * - If multiple <main> elements exist, the first will be the parent
-     */
-    private _getCanvasParent;
-    setDot(x: number, y: number, val: Color): void;
-    private _getCSSColor;
-    setText(text: string): void;
 }

--- a/build/engine.js
+++ b/build/engine.js
@@ -1,4 +1,6 @@
 "use strict";
+exports.__esModule = true;
+exports.Game = exports.Direction = exports.Color = void 0;
 /**
  * Color is a set of constants which you can use to set the color of dots.
  *
@@ -19,14 +21,14 @@ var Color;
     Color["Blue"] = "BLUE";
     Color["Indigo"] = "INDIGO";
     Color["Violet"] = "VIOLET";
-})(Color || (Color = {}));
+})(Color = exports.Color || (exports.Color = {}));
 var Direction;
 (function (Direction) {
     Direction["Left"] = "LEFT";
     Direction["Right"] = "RIGHT";
     Direction["Up"] = "UP";
     Direction["Down"] = "DOWN";
-})(Direction || (Direction = {}));
+})(Direction = exports.Direction || (exports.Direction = {}));
 /**
  * Game is the object that controls the actual running of the game. You
  * create a new one by passing in a {@Link GameConfig}. Calling `game.run()`
@@ -201,6 +203,7 @@ var Game = /** @class */ (function () {
     };
     return Game;
 }());
+exports.Game = Game;
 /**
  * @ignore
  * CanvasIOManager is the object that manages 24a2's input (capturing keyboard

--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
   "name": "24a2",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "license": "MIT",
   "devDependencies": {
     "typedoc": "^0.17.6",
     "typedoc-plugin-markdown": "^2.2.17",
     "typescript": "^3.8.3"
-  }
+  },
+  "description": "![](/website/static/img/banner.png)",
+  "type": "module",
+  "types": "build/engine.d.ts",
+  "main": "build/engine.js"
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -7,7 +7,7 @@
  * game.setDot(x, y, Color.Red)
  * ```
  */
-enum Color {
+export enum Color {
   Gray = "GRAY",
   Black = "BLACK",
   Red = "RED",
@@ -19,7 +19,7 @@ enum Color {
   Violet = "VIOLET",
 }
 
-enum Direction {
+export enum Direction {
   Left = "LEFT",
   Right = "RIGHT",
   Up = "UP",
@@ -29,7 +29,7 @@ enum Direction {
 /**
  * GameConfig is the object you pass when contructing a new {@link Game}.
  */
-interface GameConfig {
+export interface GameConfig {
   /**
    * `create(game)` is a function which is called once, just before the game
    * starts running. You can use it to initialise game state, if needed.
@@ -113,7 +113,7 @@ interface GameConfig {
  * game.run()
  * ```
  */
-class Game {
+export class Game {
   private _config: GameConfig;
 
   private _text = "";


### PR DESCRIPTION
This change allows 24a2 to be used as a node module. All this changes is exporting the public enums and interfaces in src/engine.ts. It also updates the package.json to specify that it is a module, and to point to the types and main files.

These are the same changes I made to 24a2 to use it on my own site, which uses Gatsby, so these changes should work. You can see an example of importing and using the 24a2 interfaces [here](https://github.com/micahcantor/personal-site/blob/master/src/pages/game-of-life-24a2.tsx). 

#5 